### PR TITLE
add-cli-script-support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,9 @@ setup(
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
 
-    # entry_points={
-    #     'console_scripts': ['mycli=mymodule:cli'],
-    # },
+    entry_points={
+        'console_scripts': ['jiji=jiji.__main__:main'],
+    },
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,


### PR DESCRIPTION
allows the user type:
``jiji --query ... `` to execute jiji functionalities. No need to enter Python console.